### PR TITLE
chore: use prepare instead of prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,10 @@
     "lib/index.js"
   ],
   "scripts": {
-    "build": "babel src -d lib",
-    "pretest": "standard && npm run build",
+    "prepare": "babel src -d lib",
+    "pretest": "standard && npm run prepare",
     "test": "tap test.js --100",
-    "release": "standard-version",
-    "prepublish": "npm run build"
+    "release": "standard-version"
   },
   "repository": {
     "type": "git",
@@ -37,7 +36,9 @@
     "email-addresses": "^3.0.1"
   },
   "babel": {
-    "presets": ["env"]
+    "presets": [
+      "env"
+    ]
   },
   "standard-version": {
     "scripts": {


### PR DESCRIPTION
Just trying to avoid this npm warning:

```
npm WARN prepublish-on-install As of npm@5, `prepublish` scripts are deprecated.
npm WARN prepublish-on-install Use `prepare` for build steps and `prepublishOnly` for upload-only.
npm WARN prepublish-on-install See the deprecation note in `npm help scripts` for more information.
```

Looks like a `prepare` script runs automatically on install (as last step for `npm i`) and on pack/publish (as first step for `npm pack` or `npm publish`).

To satisfy the use-case of making code changes in `src` and then running `npm t`, I also am  running it after `standard` as a `pretest` script.

The result is that it runs maybe a bit too often (runs twice when doing `npm it`), but IMO this is better than not running it enough and potentially causing confusion when just running `npm t`.

Note that `prepare` is not recognized by npm < 4, which is equivalent to Node < 7, but since we're manually calling it during `pretest`, testing in CI (or otherwise) with Node < 7 will still work - you just probably shouldn't _publish_ using those versions. Clear as mud? :+1: