### PR TITLE
fix: revert support for uppercase in slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ Accepts a single string and returns a boolean indicating if the given string is 
 
 A slug is valid if it meets the following criteria:
 
-- Starts with a letter
+- Starts with a lowercase letter
 - Is 3 to 64 characters long
-- Consists of only letters, numbers, underscores, or hyphens
+- Consists of only lowercase letters, numbers, underscores, or hyphens
 
 ### `sv.isValidPassword(string)`
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,10 @@
 
 const isEmail = require('email-addresses').parseOneAddress
 
-// must start with letter
+// must start with lowercase letter
 // must be 3-64 characters
-// can only contain letters, numbers, underscore, or hyphen
-const SLUG_REGEX = /^[A-Za-z]{1}[A-Za-z0-9_-]{2,63}$/
+// can only contain lowercase letters, numbers, underscore, or hyphen
+const SLUG_REGEX = /^[a-z]{1}[a-z0-9_-]{2,63}$/
 
 function isValidSlug (str) {
   return !!str && SLUG_REGEX.test(str)

--- a/test.js
+++ b/test.js
@@ -18,6 +18,11 @@ tap.test('isValidSlug > invalid slugs', t => {
   t.notOk(sv.isValidSlug('1aa'))
   t.notOk(sv.isValidSlug('_aa'))
   t.notOk(sv.isValidSlug('-aa'))
+  // uppercase not allowed
+  t.notOk(sv.isValidSlug('BOB'))
+  t.notOk(sv.isValidSlug('Bob'))
+  t.notOk(sv.isValidSlug('boB'))
+  t.notOk(sv.isValidSlug('SalesVista'))
   // invalid characters
   t.notOk(sv.isValidSlug('a b'))
   t.notOk(sv.isValidSlug('a`b'))
@@ -55,12 +60,6 @@ tap.test('isValidSlug > valid slugs', t => {
   t.ok(sv.isValidSlug('a_b'))
   t.ok(sv.isValidSlug('a-b'))
   t.ok(sv.isValidSlug('abc_110ec58a-a0f2-4ac4-8393-c866d813b8d1_23456789012345678901234'))
-
-  // uppercase allowed as of v1.3.0
-  t.ok(sv.isValidSlug('BOB'))
-  t.ok(sv.isValidSlug('Bob'))
-  t.ok(sv.isValidSlug('boB'))
-  t.ok(sv.isValidSlug('SalesVista'))
   t.end()
 })
 


### PR DESCRIPTION
Since we [decided](https://github.com/SalesVista/reqs/issues/371#issuecomment-452744525) to change org "Legal Name" to org "Display Name" and make it required, we no longer need to change slugs to allow uppercase letters (that change was only needed if we continued to use slugs as primary display names too). So this PR reverts the functional changes made in #7.

Supporting uppercase letters in slugs means we fundamentally have to change slug uniqueness and lookup to be case-insensitive, which is a pain I'd rather avoid.