### PR TITLE
feat: add convertToSlug function

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Options accepted:
 
     Used to turn an invalid slug (one not starting with a letter) into a valid slug, by prepending up to 3 characters of this string to the converted value.
 
+- `opts.scroll`: boolean, default `false`
+
+    Use a "scroll from right" algorithm when using the prefix to make the slug valid. The default algorithm prepends the entire prefix (when necessary), whereas the "scroll" algorithm only prepends a minimal number of characters from the prefix to make the slug valid (i.e. only uses 1 to 3 characters of the prefix instead of the whole thing).
+
 ### `sv.isValidPassword(string)`
 
 Accepts a single string and returns a boolean indicating if the given string is a valid password.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,31 @@ A slug is valid if it meets the following criteria:
 - Is 3 to 64 characters long
 - Consists of only lowercase letters, numbers, underscores, or hyphens
 
+### `sv.convertToSlug(string, opts)`
+
+Convert the given string into a valid slug.
+
+Accepts a single string (and an optional object) and returns a string.
+
+The conversion process includes:
+
+- coercing the argument into a string
+- replacing whitespace with either `'_'` or a given `opts.whitespaceReplacement`
+- removing non-alphanumeric characters
+- converting to lower-case
+- truncating to first 64 characters
+- potentially prepending a portion of `'abc'` or a given `opts.prefix` to make the slug valid
+
+Options accepted:
+
+- `opts.whitespaceReplacement`: string, default `'_'`
+
+    What to replace any whitespace with. Must make a valid slug to be used. An empty string will remove whitespace.
+
+- `opts.prefix`: string, default `'abc'`
+
+    Used to turn an invalid slug (one not starting with a letter) into a valid slug, by prepending up to 3 characters of this string to the converted value.
+
 ### `sv.isValidPassword(string)`
 
 Accepts a single string and returns a boolean indicating if the given string is a valid password.

--- a/src/index.js
+++ b/src/index.js
@@ -5,10 +5,34 @@ const isEmail = require('email-addresses').parseOneAddress
 // must start with lowercase letter
 // must be 3-64 characters
 // can only contain lowercase letters, numbers, underscore, or hyphen
-const SLUG_REGEX = /^[a-z]{1}[a-z0-9_-]{2,63}$/
+// const SLUG_REGEX = /^[a-z]{1}[a-z0-9_-]{2,63}$/
+const SLUG_MIN_LENGTH = 3
+const SLUG_MAX_LENGTH = 64
+const SLUG_REGEX = new RegExp(`^[a-z]{1}[a-z0-9_-]{${SLUG_MIN_LENGTH - 1},${SLUG_MAX_LENGTH - 1}}$`)
+const DEFAULT_SLUG_PREFIX = 'abc' // MUST be a valid slug!
+const DEFAULT_WHITESPACE_REPLACEMENT = '_'
+const DEFAULT_WHITESPACE_REPLACEMENT_RE = new RegExp(DEFAULT_WHITESPACE_REPLACEMENT, 'g')
 
 function isValidSlug (str) {
   return !!str && SLUG_REGEX.test(str)
+}
+
+function convertToSlug (str, opts) {
+  opts = opts || {}
+
+  let slug = String(str).replace(/\s/g, DEFAULT_WHITESPACE_REPLACEMENT).replace(/\W/g, '').toLowerCase()
+  if (
+    typeof opts.whitespaceReplacement === 'string' &&
+    opts.whitespaceReplacement !== DEFAULT_WHITESPACE_REPLACEMENT &&
+    isValidSlug(DEFAULT_SLUG_PREFIX + opts.whitespaceReplacement)
+  ) {
+    slug = slug.replace(DEFAULT_WHITESPACE_REPLACEMENT_RE, opts.whitespaceReplacement)
+  }
+  slug = slug.slice(0, SLUG_MAX_LENGTH)
+  if (isValidSlug(slug)) return slug
+
+  const prefix = isValidSlug(opts.prefix) ? opts.prefix : DEFAULT_SLUG_PREFIX
+  return (prefix.slice(0, Math.max(SLUG_MIN_LENGTH - slug.length, 1)) + slug).slice(0, SLUG_MAX_LENGTH)
 }
 
 // can contain any characters
@@ -24,6 +48,7 @@ function isValidEmail (str) {
 
 module.exports = {
   isValidSlug,
+  convertToSlug,
   isValidPassword,
   isValidEmail
 }

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,8 @@ function convertToSlug (str, opts) {
   if (isValidSlug(slug)) return slug
 
   const prefix = isValidSlug(opts.prefix) ? opts.prefix : DEFAULT_SLUG_PREFIX
-  return (prefix.slice(0, Math.max(SLUG_MIN_LENGTH - slug.length, 1)) + slug).slice(0, SLUG_MAX_LENGTH)
+  const pre = opts.scroll ? prefix.slice(0, Math.max(SLUG_MIN_LENGTH - slug.length, 1)) : prefix
+  return (pre + slug).slice(0, SLUG_MAX_LENGTH)
 }
 
 // can contain any characters

--- a/test.js
+++ b/test.js
@@ -63,6 +63,75 @@ tap.test('isValidSlug > valid slugs', t => {
   t.end()
 })
 
+tap.test('convertToSlug > no opts', t => {
+  t.strictEqual(sv.convertToSlug('One Two Three, LLC'), 'one_two_three_llc')
+  t.strictEqual(sv.convertToSlug('1.2.3 ABC Corp'), 'a123_abc_corp')
+  t.strictEqual(sv.convertToSlug('1@gmail.com'), 'a1gmailcom')
+  t.strictEqual(sv.convertToSlug('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum ante leo'), 'lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_vestibulu')
+  t.strictEqual(sv.convertToSlug('包'), 'abc')
+  t.strictEqual(sv.convertToSlug(), 'undefined')
+  t.strictEqual(sv.convertToSlug(null), 'null')
+  t.strictEqual(sv.convertToSlug(''), 'abc')
+  t.strictEqual(sv.convertToSlug(' '), 'ab_')
+  t.strictEqual(sv.convertToSlug('  '), 'a__')
+  t.strictEqual(sv.convertToSlug('   '), 'a___')
+  t.strictEqual(sv.convertToSlug(1), 'ab1')
+  t.strictEqual(sv.convertToSlug(12), 'a12')
+  t.strictEqual(sv.convertToSlug(1.2), 'a12')
+  t.strictEqual(sv.convertToSlug(1.2345), 'a12345')
+  t.strictEqual(sv.convertToSlug(true), 'true')
+  t.strictEqual(sv.convertToSlug(false), 'false')
+  t.strictEqual(sv.convertToSlug(/x/), 'abx')
+  t.strictEqual(sv.convertToSlug({}), 'object_object')
+  t.strictEqual(sv.convertToSlug([]), 'abc')
+  t.strictEqual(sv.convertToSlug([1]), 'ab1')
+  t.strictEqual(sv.convertToSlug([1, 'x']), 'a1x')
+  t.strictEqual(sv.convertToSlug(function x () {}), 'function_x__')
+  t.strictEqual(sv.convertToSlug(() => {}), 'a__')
+  t.ok(sv.isValidSlug(sv.convertToSlug(new Date())))
+  t.end()
+})
+
+tap.test('convertToSlug > opts', t => {
+  // valid opts
+  t.strictEqual(
+    sv.convertToSlug('One Two Three, LLC', { whitespaceReplacement: '-' }),
+    'one-two-three-llc'
+  )
+  t.strictEqual(
+    sv.convertToSlug('One Two Three, LLC', { whitespaceReplacement: '' }),
+    'onetwothreellc'
+  )
+  t.strictEqual(
+    sv.convertToSlug('One Two Three, LLC', { whitespaceReplacement: 'salesvista' }),
+    'onesalesvistatwosalesvistathreesalesvistallc'
+  )
+  t.strictEqual(
+    sv.convertToSlug('1.2.3 ABC Corp', { whitespaceReplacement: '', prefix: 'salesvista' }),
+    's123abccorp'
+  )
+  t.strictEqual(sv.convertToSlug('', { prefix: 'luvmuffin' }), 'luv')
+  t.strictEqual(sv.convertToSlug('1 2', { prefix: 'luvmuffin' }), 'l1_2')
+
+  // invalid/ignored opts
+  t.strictEqual(
+    sv.convertToSlug('One Two Three', { whitespaceReplacement: false }), // must be a string
+    'one_two_three'
+  )
+  t.strictEqual(
+    sv.convertToSlug('One Two Three', { whitespaceReplacement: '@' }), // must make valid slug
+    'one_two_three'
+  )
+  t.strictEqual(sv.convertToSlug('', { prefix: '123' }), 'abc') // prefix must be valid slug
+  t.strictEqual(sv.convertToSlug('1 2', { prefix: '123' }), 'a1_2')
+  t.strictEqual(sv.convertToSlug('', { prefix: 'x' }), 'abc')
+  t.strictEqual(sv.convertToSlug('1 2', { prefix: 'x' }), 'a1_2')
+  t.strictEqual(sv.convertToSlug('', { prefix: 'XYZ' }), 'abc')
+  t.strictEqual(sv.convertToSlug('1 2', { prefix: 'XYZ' }), 'a1_2')
+
+  t.end()
+})
+
 tap.test('isValidPassword', t => {
   // invalid passwords
   t.notOk(sv.isValidPassword())

--- a/test.js
+++ b/test.js
@@ -65,34 +65,65 @@ tap.test('isValidSlug > valid slugs', t => {
 
 tap.test('convertToSlug > no opts', t => {
   t.strictEqual(sv.convertToSlug('One Two Three, LLC'), 'one_two_three_llc')
-  t.strictEqual(sv.convertToSlug('1.2.3 ABC Corp'), 'a123_abc_corp')
-  t.strictEqual(sv.convertToSlug('1@gmail.com'), 'a1gmailcom')
+  t.strictEqual(sv.convertToSlug('1.2.3 ABC Corp'), 'abc123_abc_corp')
+  t.strictEqual(sv.convertToSlug('1@gmail.com'), 'abc1gmailcom')
   t.strictEqual(sv.convertToSlug('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum ante leo'), 'lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_vestibulu')
   t.strictEqual(sv.convertToSlug('包'), 'abc')
   t.strictEqual(sv.convertToSlug(), 'undefined')
   t.strictEqual(sv.convertToSlug(null), 'null')
   t.strictEqual(sv.convertToSlug(''), 'abc')
-  t.strictEqual(sv.convertToSlug(' '), 'ab_')
-  t.strictEqual(sv.convertToSlug('  '), 'a__')
-  t.strictEqual(sv.convertToSlug('   '), 'a___')
-  t.strictEqual(sv.convertToSlug(1), 'ab1')
-  t.strictEqual(sv.convertToSlug(12), 'a12')
-  t.strictEqual(sv.convertToSlug(1.2), 'a12')
-  t.strictEqual(sv.convertToSlug(1.2345), 'a12345')
+  t.strictEqual(sv.convertToSlug(' '), 'abc_')
+  t.strictEqual(sv.convertToSlug('  '), 'abc__')
+  t.strictEqual(sv.convertToSlug('   '), 'abc___')
+  t.strictEqual(sv.convertToSlug(1), 'abc1')
+  t.strictEqual(sv.convertToSlug(12), 'abc12')
+  t.strictEqual(sv.convertToSlug(1.2), 'abc12')
+  t.strictEqual(sv.convertToSlug(1.2345), 'abc12345')
   t.strictEqual(sv.convertToSlug(true), 'true')
   t.strictEqual(sv.convertToSlug(false), 'false')
-  t.strictEqual(sv.convertToSlug(/x/), 'abx')
+  t.strictEqual(sv.convertToSlug(/x/), 'abcx')
   t.strictEqual(sv.convertToSlug({}), 'object_object')
   t.strictEqual(sv.convertToSlug([]), 'abc')
-  t.strictEqual(sv.convertToSlug([1]), 'ab1')
-  t.strictEqual(sv.convertToSlug([1, 'x']), 'a1x')
+  t.strictEqual(sv.convertToSlug([1]), 'abc1')
+  t.strictEqual(sv.convertToSlug([1, 'x']), 'abc1x')
   t.strictEqual(sv.convertToSlug(function x () {}), 'function_x__')
-  t.strictEqual(sv.convertToSlug(() => {}), 'a__')
+  t.strictEqual(sv.convertToSlug(() => {}), 'abc__')
   t.ok(sv.isValidSlug(sv.convertToSlug(new Date())))
   t.end()
 })
 
-tap.test('convertToSlug > opts', t => {
+tap.test('convertToSlug > scroll', t => {
+  const scroll = { scroll: true }
+  t.strictEqual(sv.convertToSlug('One Two Three, LLC', scroll), 'one_two_three_llc')
+  t.strictEqual(sv.convertToSlug('1.2.3 ABC Corp', scroll), 'a123_abc_corp')
+  t.strictEqual(sv.convertToSlug('1@gmail.com', scroll), 'a1gmailcom')
+  t.strictEqual(sv.convertToSlug('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum ante leo', scroll), 'lorem_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_vestibulu')
+  t.strictEqual(sv.convertToSlug('包', scroll), 'abc')
+  let u
+  t.strictEqual(sv.convertToSlug(u, scroll), 'undefined')
+  t.strictEqual(sv.convertToSlug(null, scroll), 'null')
+  t.strictEqual(sv.convertToSlug('', scroll), 'abc')
+  t.strictEqual(sv.convertToSlug(' ', scroll), 'ab_')
+  t.strictEqual(sv.convertToSlug('  ', scroll), 'a__')
+  t.strictEqual(sv.convertToSlug('   ', scroll), 'a___')
+  t.strictEqual(sv.convertToSlug(1, scroll), 'ab1')
+  t.strictEqual(sv.convertToSlug(12, scroll), 'a12')
+  t.strictEqual(sv.convertToSlug(1.2, scroll), 'a12')
+  t.strictEqual(sv.convertToSlug(1.2345, scroll), 'a12345')
+  t.strictEqual(sv.convertToSlug(true, scroll), 'true')
+  t.strictEqual(sv.convertToSlug(false, scroll), 'false')
+  t.strictEqual(sv.convertToSlug(/x/, scroll), 'abx')
+  t.strictEqual(sv.convertToSlug({}, scroll), 'object_object')
+  t.strictEqual(sv.convertToSlug([], scroll), 'abc')
+  t.strictEqual(sv.convertToSlug([1], scroll), 'ab1')
+  t.strictEqual(sv.convertToSlug([1, 'x'], scroll), 'a1x')
+  t.strictEqual(sv.convertToSlug(function x () {}, scroll), 'function_x__')
+  t.strictEqual(sv.convertToSlug(() => {}, scroll), 'a__')
+  t.ok(sv.isValidSlug(sv.convertToSlug(new Date(), scroll)))
+  t.end()
+})
+
+tap.test('convertToSlug > other opts', t => {
   // valid opts
   t.strictEqual(
     sv.convertToSlug('One Two Three, LLC', { whitespaceReplacement: '-' }),
@@ -108,10 +139,16 @@ tap.test('convertToSlug > opts', t => {
   )
   t.strictEqual(
     sv.convertToSlug('1.2.3 ABC Corp', { whitespaceReplacement: '', prefix: 'salesvista' }),
+    'salesvista123abccorp'
+  )
+  t.strictEqual(
+    sv.convertToSlug('1.2.3 ABC Corp', { whitespaceReplacement: '', prefix: 'salesvista', scroll: true }),
     's123abccorp'
   )
-  t.strictEqual(sv.convertToSlug('', { prefix: 'luvmuffin' }), 'luv')
-  t.strictEqual(sv.convertToSlug('1 2', { prefix: 'luvmuffin' }), 'l1_2')
+  t.strictEqual(sv.convertToSlug('', { prefix: 'luvmuffin' }), 'luvmuffin')
+  t.strictEqual(sv.convertToSlug('1 2', { prefix: 'luvmuffin' }), 'luvmuffin1_2')
+  t.strictEqual(sv.convertToSlug('', { prefix: 'luvmuffin', scroll: true }), 'luv')
+  t.strictEqual(sv.convertToSlug('1 2', { prefix: 'luvmuffin', scroll: true }), 'l1_2')
 
   // invalid/ignored opts
   t.strictEqual(
@@ -123,11 +160,14 @@ tap.test('convertToSlug > opts', t => {
     'one_two_three'
   )
   t.strictEqual(sv.convertToSlug('', { prefix: '123' }), 'abc') // prefix must be valid slug
-  t.strictEqual(sv.convertToSlug('1 2', { prefix: '123' }), 'a1_2')
+  t.strictEqual(sv.convertToSlug('1 2', { prefix: '123' }), 'abc1_2')
+  t.strictEqual(sv.convertToSlug('1 2', { prefix: '123', scroll: true }), 'a1_2')
   t.strictEqual(sv.convertToSlug('', { prefix: 'x' }), 'abc')
-  t.strictEqual(sv.convertToSlug('1 2', { prefix: 'x' }), 'a1_2')
+  t.strictEqual(sv.convertToSlug('1 2', { prefix: 'x' }), 'abc1_2')
+  t.strictEqual(sv.convertToSlug('1 2', { prefix: 'x', scroll: true }), 'a1_2')
   t.strictEqual(sv.convertToSlug('', { prefix: 'XYZ' }), 'abc')
-  t.strictEqual(sv.convertToSlug('1 2', { prefix: 'XYZ' }), 'a1_2')
+  t.strictEqual(sv.convertToSlug('1 2', { prefix: 'XYZ' }), 'abc1_2')
+  t.strictEqual(sv.convertToSlug('1 2', { prefix: 'XYZ', scroll: true }), 'a1_2')
 
   t.end()
 })


### PR DESCRIPTION
Adds a new function to the main export that will allow us to, in a consistent manner on frontend and backend, generate a valid slug from any given input.

Supports options for (a) what to replace whitespace with, (b) what to use as a prefix if the input does not start with a letter or is not long enough, and (c) which prefix algorithm to use.