### PR TITLE
feat: change password validation from 6 to 12 characters

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,8 @@ jobs:
       matrix:
         node-version:
           # - latest (aliases not yet supported, see https://github.com/actions/setup-node/issues/26)
+          - 16
           - 14
-          - 12
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/src/index.js
+++ b/src/index.js
@@ -37,9 +37,9 @@ function convertToSlug (str, opts) {
 }
 
 // can contain any characters
-// must be at least 6 characters long
+// must be at least 12 characters long
 function isValidPassword (str) {
-  return !!str && str.length > 5
+  return !!str && str.length > 11
 }
 
 // just re-use this other person's work

--- a/test.js
+++ b/test.js
@@ -183,7 +183,7 @@ tap.test('isValidPassword', t => {
   t.ok(sv.isValidPassword('!@#$%$^&*()#'))
   t.ok(sv.isValidPassword('undefinedabcd'))
   t.ok(sv.isValidPassword('   some super cool long password that nobody knows'))
-  t.ok(sv.isValidPassword('           '))
+  t.ok(sv.isValidPassword('            '))
   t.end()
 })
 

--- a/test.js
+++ b/test.js
@@ -176,14 +176,14 @@ tap.test('isValidPassword', t => {
   // invalid passwords
   t.notOk(sv.isValidPassword())
   t.notOk(sv.isValidPassword(null))
-  t.notOk(sv.isValidPassword('12345'))
+  t.notOk(sv.isValidPassword('123456'))
 
   // valid passwords
-  t.ok(sv.isValidPassword('password'))
-  t.ok(sv.isValidPassword('!@#$%$^'))
-  t.ok(sv.isValidPassword('undefined'))
+  t.ok(sv.isValidPassword('password1234'))
+  t.ok(sv.isValidPassword('!@#$%$^&*()'))
+  t.ok(sv.isValidPassword('undefinedabcd'))
   t.ok(sv.isValidPassword('   some super cool long password that nobody knows'))
-  t.ok(sv.isValidPassword('      '))
+  t.ok(sv.isValidPassword('           '))
   t.end()
 })
 

--- a/test.js
+++ b/test.js
@@ -180,7 +180,7 @@ tap.test('isValidPassword', t => {
 
   // valid passwords
   t.ok(sv.isValidPassword('password1234'))
-  t.ok(sv.isValidPassword('!@#$%$^&*()'))
+  t.ok(sv.isValidPassword('!@#$%$^&*()#'))
   t.ok(sv.isValidPassword('undefinedabcd'))
   t.ok(sv.isValidPassword('   some super cool long password that nobody knows'))
   t.ok(sv.isValidPassword('           '))


### PR DESCRIPTION
changes the required number of characters for password validation from 6 characters to 12.
relates to: https://github.com/SalesVista/reqs/issues/1268