### PR TITLE
feat: hyphens optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A slug is valid if it meets the following criteria:
 - Starts with a lowercase letter
 - Is 3 to 64 characters long
 - Consists of only lowercase letters, numbers, underscores, or hyphens
+- hyphens can be disabled with option `{ allowHyphen: false }`
 
 ### `sv.convertToSlug(string, opts)`
 
@@ -62,6 +63,14 @@ Options accepted:
 - `opts.scroll`: boolean, default `false`
 
     Use a "scroll from right" algorithm when using the prefix to make the slug valid. The default algorithm prepends the entire prefix (when necessary), whereas the "scroll" algorithm only prepends a minimal number of characters from the prefix to make the slug valid (i.e. only uses 1 to 3 characters of the prefix instead of the whole thing).
+
+- `opts.allowHyphen`: boolean, default `true`
+
+    When `false`, hyphens are not valid in slugs. `convertToSlug` will replace any hyphen characters using `opts.hyphenReplacement`.
+
+- `opts.hyphenReplacement`: string, default `'_'`
+
+    What to replace hyphens with when `allowHyphen` is `false`. Set to an empty string to remove them entirely.
 
 ### `sv.isValidPassword(string)`
 

--- a/test.js
+++ b/test.js
@@ -63,6 +63,12 @@ tap.test('isValidSlug > valid slugs', t => {
   t.end()
 })
 
+tap.test('isValidSlug > allowHyphen false', t => {
+  t.notOk(sv.isValidSlug('a-b', { allowHyphen: false }))
+  t.ok(sv.isValidSlug('a_b', { allowHyphen: false }))
+  t.end()
+})
+
 tap.test('convertToSlug > no opts', t => {
   t.strictEqual(sv.convertToSlug('One Two Three, LLC'), 'one_two_three_llc')
   t.strictEqual(sv.convertToSlug('1.2.3 ABC Corp'), 'abc123_abc_corp')
@@ -169,6 +175,19 @@ tap.test('convertToSlug > other opts', t => {
   t.strictEqual(sv.convertToSlug('1 2', { prefix: 'XYZ' }), 'abc1_2')
   t.strictEqual(sv.convertToSlug('1 2', { prefix: 'XYZ', scroll: true }), 'a1_2')
 
+  t.end()
+})
+
+tap.test('convertToSlug > allowHyphen false', t => {
+  t.strictEqual(sv.convertToSlug('foo-bar', { allowHyphen: false }), 'foo_bar')
+  t.strictEqual(
+    sv.convertToSlug('foo-bar', { allowHyphen: false, hyphenReplacement: '' }),
+    'foobar'
+  )
+  t.strictEqual(
+    sv.convertToSlug('foo bar', { allowHyphen: false, whitespaceReplacement: '-' }),
+    'foo_bar'
+  )
   t.end()
 })
 


### PR DESCRIPTION
new option(s) to slug validation and conversion that treat hyphens as invalid characters in slugs. 

validation example:
- `isValidSlug('my-slug')` => true
- `isValidSlug('my-slug', { allowHyphen: false })` => false

conversion example:
- `convertToSlug('my-example')` => `my-example`
- `convertToSlug('my-example', { allowHyphen: false })` => `my_example`
- `convertToSlug('my-example', { allowHyphen: false, hyphenReplacement: '' })` => `myexample`