### PR TITLE
chore: grant release-please issue permission, update deprecated action reference

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,13 +7,14 @@ on:
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         id: release
         with:
           release-type: node


### PR DESCRIPTION
- explicitly grant issue perm so labels can be created (see conversation [here](https://github.com/googleapis/release-please-action/issues/1105#issuecomment-2780292262)). doubt this is really needed since i just manually created the labels so the job can run successfully, but adding none-the-less
- update deprecated action reference based on warning in [latest execution](https://github.com/SalesVista/stateless-validation/actions/runs/15719239387)
    > google-github-actions/release-please-action is deprecated, please use googleapis/release-please-action instead.